### PR TITLE
Fix: get rid of "can_reset" and "can_mode".

### DIFF
--- a/include/can_api.h
+++ b/include/can_api.h
@@ -94,11 +94,9 @@ void          can_handle_data();
 void          can_init(can_t *obj, CANName peripheral, CanNominalBitTimingResult const can_bit_timing);
 int           can_frequency(can_t *obj, uint32_t const can_bitrate);
 
-int           can_write(can_t *obj, union x8h7_can_message const * msg);
+void          can_write(can_t *obj, union x8h7_can_message const * msg);
 int           can_read(can_t *obj, union x8h7_can_message *msg);
-int           can_mode(can_t *obj, CanMode mode);
 int           can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t handle);
-void          can_reset(can_t *obj);
 unsigned char can_rderror(can_t *obj);
 unsigned char can_tderror(can_t *obj);
 


### PR DESCRIPTION
Both aren't actually very useful, i.e. can_mode is only called by can_reset. And can_reset is only called when pushing frames to the TX FIFO fails. In this case its adequately pushed back to the linux firmware driver who then may - or may not - trigger a complete reinitialsation. At any rate, the device firmware driver should be as dumb as possible.