### PR TITLE
Fix: align function naming style and file name for CAN.

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -70,10 +70,10 @@ typedef enum {
  * FUNCTION DECLARATION
  **************************************************************************************/
 
-void          canInit();
+void          can_init();
 void          can_handle_data();
 
-void          can_init(FDCAN_HandleTypeDef * handle, CANName peripheral, CanNominalBitTimingResult const can_bit_timing);
+void          can_init_device(FDCAN_HandleTypeDef * handle, CANName peripheral, CanNominalBitTimingResult const can_bit_timing);
 int           can_frequency(FDCAN_HandleTypeDef * handle, uint32_t const can_bitrate);
 
 void          can_write(FDCAN_HandleTypeDef * handle, union x8h7_can_message const * msg);

--- a/src/can.c
+++ b/src/can.c
@@ -23,7 +23,8 @@
 #include <stdbool.h>
 #include <string.h>
 #include <stdio.h>
-#include "can_api.h"
+
+#include "can.h"
 #include "stm32h7xx_ll_hsem.h"
 #include "system.h"
 #include "peripherals.h"
@@ -225,7 +226,7 @@ void fdcan2_handler(uint8_t opcode, uint8_t *data, uint16_t size) {
 }
 
 
-void canInit()
+void can_init()
 {
   CanNominalBitTimingResult default_can_bit_timing = {0};
 
@@ -243,8 +244,8 @@ void canInit()
     return;
   }
 
-  can_init(&fdcan_1, CAN_1, default_can_bit_timing);
-  can_init(&fdcan_2, CAN_2, default_can_bit_timing);
+  can_init_device(&fdcan_1, CAN_1, default_can_bit_timing);
+  can_init_device(&fdcan_2, CAN_2, default_can_bit_timing);
 
   register_peripheral_callback(PERIPH_FDCAN1, &fdcan1_handler);
   register_peripheral_callback(PERIPH_FDCAN2, &fdcan2_handler);
@@ -294,7 +295,7 @@ int can_internal_init(FDCAN_HandleTypeDef * handle)
     return 1;
 }
 
-void can_init(FDCAN_HandleTypeDef * handle, CANName peripheral, CanNominalBitTimingResult const can_bit_timing)
+void can_init_device(FDCAN_HandleTypeDef * handle, CANName peripheral, CanNominalBitTimingResult const can_bit_timing)
 {
     __HAL_RCC_FDCAN_CLK_ENABLE();
     HAL_RCC_FDCAN_CLK_ENABLED++;

--- a/src/main.c
+++ b/src/main.c
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include "peripherals.h"
 #include "ringbuffer.h"
-#include "can_api.h"
+#include "can.h"
 #include "rpc.h"
 #include "adc.h"
 #include "uart.h"
@@ -67,7 +67,7 @@ void peripheral_init() {
 
   adc_init();
 
-  canInit();
+  can_init();
 }
 
 void handle_data() {

--- a/src/system.c
+++ b/src/system.c
@@ -28,7 +28,7 @@
 #include "adc.h"
 #include "pwm.h"
 #include "gpio.h"
-#include "can_api.h"
+#include "can.h"
 #include "rtc.h"
 #include "uart.h"
 #include "rpc.h"


### PR DESCRIPTION
No more mixed CamelCase and underscore_case mixed.