### PR TITLE
Fix: only transport relevant CAN frame payload via IMX8 / H7 brigde.

### DIFF
--- a/include/peripherals.h
+++ b/include/peripherals.h
@@ -68,6 +68,7 @@ enum Opcodes_RTC {
 
 enum Opcodes_CAN {
   CAN_TX_FRAME = 0x01,
+  CAN_RX_FRAME = 0x01,
   CAN_STATUS = 0x40,
   CAN_FILTER = 0x50,
 };

--- a/src/can.c
+++ b/src/can.c
@@ -255,12 +255,20 @@ void can_handle_data()
 {
   union x8h7_can_frame_message msg;
 
-  if (can_read(&fdcan_1, &msg)) {
-    enqueue_packet(PERIPH_FDCAN1, DATA, sizeof(msg.buf), msg.buf);
+  if (can_read(&fdcan_1, &msg))
+  {
+    enqueue_packet(PERIPH_FDCAN1,
+                   DATA,
+                   X8H7_CAN_HEADER_SIZE + msg.field.len,
+                   msg.buf);
   }
 
-  if (can_read(&fdcan_2, &msg)) {
-    enqueue_packet(PERIPH_FDCAN2, DATA, sizeof(msg.buf), msg.buf);
+  if (can_read(&fdcan_2, &msg))
+  {
+    enqueue_packet(PERIPH_FDCAN2,
+                   DATA,
+                   X8H7_CAN_HEADER_SIZE + msg.field.len,
+                   msg.buf);
   }
 }
 

--- a/src/can.c
+++ b/src/can.c
@@ -258,7 +258,7 @@ void can_handle_data()
   if (can_read(&fdcan_1, &msg))
   {
     enqueue_packet(PERIPH_FDCAN1,
-                   DATA,
+                   CAN_RX_FRAME,
                    X8H7_CAN_HEADER_SIZE + msg.field.len,
                    msg.buf);
   }
@@ -266,7 +266,7 @@ void can_handle_data()
   if (can_read(&fdcan_2, &msg))
   {
     enqueue_packet(PERIPH_FDCAN2,
-                   DATA,
+                   CAN_RX_FRAME,
                    X8H7_CAN_HEADER_SIZE + msg.field.len,
                    msg.buf);
   }


### PR DESCRIPTION
There's no need to send the full 8 bytes if there's nothing relevant in them, i.e. the DLC being < 8. Note: the linux CAN driver can already handle this behavious.