### PR TITLE
Fix/FDCAN2: provide correct handle for "HAL_FDCAN_IRQHandler".

### DIFF
--- a/src/stm32h7xx_it.c
+++ b/src/stm32h7xx_it.c
@@ -23,7 +23,7 @@
 
 /* External variables --------------------------------------------------------*/
 extern FDCAN_HandleTypeDef fdcan_1;
-extern FDCAN_HandleTypeDef fdcan_1;
+extern FDCAN_HandleTypeDef fdcan_2;
 extern DMA_HandleTypeDef hdma_spi3_tx;
 extern DMA_HandleTypeDef hdma_spi3_rx;
 extern SPI_HandleTypeDef hspi3;
@@ -155,7 +155,7 @@ void FDCAN1_IT0_IRQHandler(void) {
  * @brief This function handles FDCAN2 interrupt 0.
  */
 void FDCAN2_IT0_IRQHandler(void) {
-  HAL_FDCAN_IRQHandler(&fdcan_1);
+  HAL_FDCAN_IRQHandler(&fdcan_2);
 }
 
 /**


### PR DESCRIPTION
Incorrect handle did not cause bug because the current design does not emply interrupts, however this may be subject to change in the near future.